### PR TITLE
Add container image mirror for the docker daemon

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -6,5 +6,6 @@
     "max-file": "10"
   },
   "live-restore": true,
-  "max-concurrent-downloads": 10
+  "max-concurrent-downloads": 10,
+  "registry-mirrors": ["https://docker-registry.eu-central-1.tier-services.io"]
 }


### PR DESCRIPTION
In order to lower the amount of public pulls as well as enable faster serving of images, we change the upstream url to a local pull through cache.